### PR TITLE
use jpa with hibernate instead of reactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,8 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/io/github/opendme/server/entity/Department.java
+++ b/src/main/java/io/github/opendme/server/entity/Department.java
@@ -1,4 +1,12 @@
 package io.github.opendme.server.entity;
 
-public record Department(Long id, String name, Long adminId)  {
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public record Department(
+        @Id
+        Long id,
+        String name,
+        Long adminId) {
 }

--- a/src/main/java/io/github/opendme/server/entity/Member.java
+++ b/src/main/java/io/github/opendme/server/entity/Member.java
@@ -1,6 +1,15 @@
 package io.github.opendme.server.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
 import java.util.List;
 
-public record Member(Long id, Long departmentId, String name, List<Skill> skills) {
+@Entity
+public record Member(
+        @Id
+        Long id,
+        Long departmentId,
+        String name,
+        List<Skill> skills) {
 }

--- a/src/main/java/io/github/opendme/server/entity/MemberRepository.java
+++ b/src/main/java/io/github/opendme/server/entity/MemberRepository.java
@@ -1,8 +1,9 @@
 package io.github.opendme.server.entity;
 
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
-import reactor.core.publisher.Flux;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends ReactiveCrudRepository<Member, Long> {
-    Flux<Member> findAllByDepartmentId(Long departmentId);
+import java.util.List;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    List<Member> findAllByDepartmentId(Long departmentId);
 }

--- a/src/main/java/io/github/opendme/server/entity/Skill.java
+++ b/src/main/java/io/github/opendme/server/entity/Skill.java
@@ -1,4 +1,11 @@
 package io.github.opendme.server.entity;
 
-public record Skill(Long id, String name) {
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public record Skill(
+        @Id
+        Long id,
+        String name) {
 }

--- a/src/main/java/io/github/opendme/server/entity/Vehicle.java
+++ b/src/main/java/io/github/opendme/server/entity/Vehicle.java
@@ -1,6 +1,15 @@
 package io.github.opendme.server.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
 import java.util.Map;
 
-public record Vehicle(Long id, String name, Integer seats, Map<Skill, Integer> requiredSkills) {
+@Entity
+public record Vehicle(
+        @Id
+        Long id,
+        String name,
+        Integer seats,
+        Map<Skill, Integer> requiredSkills) {
 }


### PR DESCRIPTION
Integrating reactor with hibernate is too much of a hassle.

We will stop using reactor and stick to standard JPA.