### PR TITLE
member controller

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 

--- a/src/main/java/io/github/opendme/server/controller/DepartmentController.java
+++ b/src/main/java/io/github/opendme/server/controller/DepartmentController.java
@@ -3,6 +3,9 @@ package io.github.opendme.server.controller;
 import io.github.opendme.server.entity.Department;
 import io.github.opendme.server.entity.DepartmentDto;
 import io.github.opendme.server.service.DepartmentService;
+import jakarta.validation.Valid;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class DepartmentController {
+    private static final Logger log = LogManager.getLogger(DepartmentController.class);
     DepartmentService service;
 
     public DepartmentController(DepartmentService service) {
@@ -18,9 +22,9 @@ public class DepartmentController {
 
     @PostMapping(value = "/department", produces = "application/json;charset=UTF-8")
     @ResponseBody
-    public Department create(@RequestBody DepartmentDto department) {
+    public Department create(@RequestBody @Valid DepartmentDto department) {
         Department department1 = service.create(department);
-        System.out.println("Department created");
+        log.atInfo().log("Department created");
 
         return department1;
     }

--- a/src/main/java/io/github/opendme/server/controller/MemberController.java
+++ b/src/main/java/io/github/opendme/server/controller/MemberController.java
@@ -1,0 +1,31 @@
+package io.github.opendme.server.controller;
+
+import io.github.opendme.server.entity.Member;
+import io.github.opendme.server.entity.MemberDto;
+import io.github.opendme.server.service.MemberService;
+import jakarta.validation.Valid;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+    private static final Logger log = LogManager.getLogger(MemberController.class);
+    MemberService service;
+
+    public MemberController(MemberService service) {
+        this.service = service;
+    }
+
+    @PostMapping(value = "/member", produces = "application/json;charset=UTF-8")
+    @ResponseBody
+    public Member create(@RequestBody @Valid MemberDto dto) {
+        Member member = service.create(dto);
+        log.atInfo().log("Member created");
+
+        return member;
+    }
+}

--- a/src/main/java/io/github/opendme/server/entity/Department.java
+++ b/src/main/java/io/github/opendme/server/entity/Department.java
@@ -20,7 +20,7 @@ public class Department {
     private Long id;
     private String name;
 
-    @OneToOne(optional = false, orphanRemoval = true)
+    @OneToOne(optional = false)
     private Member admin;
 
     public Department() {

--- a/src/main/java/io/github/opendme/server/entity/Department.java
+++ b/src/main/java/io/github/opendme/server/entity/Department.java
@@ -1,9 +1,9 @@
 package io.github.opendme.server.entity;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToOne;
 import java.util.Objects;
 
 @Entity
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 @SuppressWarnings("unused")
 public class Department {
     @Id
@@ -19,8 +20,7 @@ public class Department {
     private Long id;
     private String name;
 
-    @JsonManagedReference
-    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @OneToOne(optional = false, orphanRemoval = true)
     private Member admin;
 
     public Department() {

--- a/src/main/java/io/github/opendme/server/entity/DepartmentDto.java
+++ b/src/main/java/io/github/opendme/server/entity/DepartmentDto.java
@@ -1,5 +1,8 @@
 package io.github.opendme.server.entity;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -7,7 +10,9 @@ import java.util.Objects;
  * DTO for {@link Department}
  */
 public class DepartmentDto implements Serializable {
+    @NotEmpty
     private final String name;
+    @NotNull
     private final Long adminId;
 
     public DepartmentDto(String name, Long adminId) {

--- a/src/main/java/io/github/opendme/server/entity/DepartmentRepository.java
+++ b/src/main/java/io/github/opendme/server/entity/DepartmentRepository.java
@@ -3,5 +3,4 @@ package io.github.opendme.server.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
-
 }

--- a/src/main/java/io/github/opendme/server/entity/Member.java
+++ b/src/main/java/io/github/opendme/server/entity/Member.java
@@ -63,6 +63,22 @@ public class Member {
         return email;
     }
 
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setSkills(Set<Skill> skills) {
+        this.skills = skills;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;

--- a/src/main/java/io/github/opendme/server/entity/Member.java
+++ b/src/main/java/io/github/opendme/server/entity/Member.java
@@ -1,6 +1,7 @@
 package io.github.opendme.server.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -12,12 +13,12 @@ import java.util.Objects;
 import java.util.Set;
 
 @Entity
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 @SuppressWarnings("unused")
 public class Member {
     @Id
     @GeneratedValue
     private Long id;
-    @JsonBackReference
     @ManyToOne
     private Department department;
     private String name;

--- a/src/main/java/io/github/opendme/server/entity/MemberDto.java
+++ b/src/main/java/io/github/opendme/server/entity/MemberDto.java
@@ -1,30 +1,30 @@
 package io.github.opendme.server.entity;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * DTO for {@link Member}
  */
 public class MemberDto implements Serializable {
-    private final Long id;
     private final Long departmentId;
+    @NotEmpty(message = "Name can not be empty")
     private final String name;
-    private final Set<Long> skillIds;
+    private final List<Long> skillIds;
+    @Pattern(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "Email must be valid")
     private final String email;
 
-    public MemberDto(Long id, Long departmentId, String name, Set<Long> skillIds, String email) {
-        this.id = id;
+    public MemberDto(Long departmentId, String name, List<Long> skillIds, String email) {
         this.departmentId = departmentId;
         this.name = name;
         this.skillIds = skillIds;
         this.email = email;
     }
 
-    public Long getId() {
-        return id;
-    }
 
     public Long getDepartmentId() {
         return departmentId;
@@ -34,7 +34,7 @@ public class MemberDto implements Serializable {
         return name;
     }
 
-    public Set<Long> getSkillIds() {
+    public List<Long> getSkillIds() {
         return skillIds;
     }
 
@@ -47,8 +47,7 @@ public class MemberDto implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MemberDto entity = (MemberDto) o;
-        return Objects.equals(this.id, entity.id) &&
-                Objects.equals(this.departmentId, entity.departmentId) &&
+        return Objects.equals(this.departmentId, entity.departmentId) &&
                 Objects.equals(this.name, entity.name) &&
                 Objects.equals(this.skillIds, entity.skillIds) &&
                 Objects.equals(this.email, entity.email);
@@ -56,13 +55,12 @@ public class MemberDto implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, departmentId, name, skillIds, email);
+        return Objects.hash(departmentId, name, skillIds, email);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" +
-                "id = " + id + ", " +
                 "departmentId = " + departmentId + ", " +
                 "name = " + name + ", " +
                 "skillIds = " + skillIds + ", " +

--- a/src/main/java/io/github/opendme/server/entity/MemberRepository.java
+++ b/src/main/java/io/github/opendme/server/entity/MemberRepository.java
@@ -1,9 +1,27 @@
 package io.github.opendme.server.entity;
 
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByDepartmentId(Long departmentId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Member m SET m.department = NULL WHERE m.department = :department")
+    void removeDepartment(@Param("department") Department department);
+
+    /**
+     * Removes all department references.<br/>
+     * <b>Just for testing!</b>
+     */
+    @Transactional
+    @Modifying
+    @Query("UPDATE Member m SET m.department = NULL")
+    void removeAllDepartments();
 }

--- a/src/main/java/io/github/opendme/server/entity/Skill.java
+++ b/src/main/java/io/github/opendme/server/entity/Skill.java
@@ -1,12 +1,40 @@
 package io.github.opendme.server.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity
-public record Skill(
+public class Skill {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         @Column(nullable = false)
-        Long id,
-        String name) {
+        Long id;
+    String name;
+
+    public Skill() {
+    }
+
+    public Skill(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/io/github/opendme/server/entity/SkillRepository.java
+++ b/src/main/java/io/github/opendme/server/entity/SkillRepository.java
@@ -2,5 +2,11 @@ package io.github.opendme.server.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Set;
+
 public interface SkillRepository extends JpaRepository<Skill, Long> {
+    long countAllByIdIn(List<Long> ids);
+
+    Set<Skill> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/io/github/opendme/server/entity/Vehicle.java
+++ b/src/main/java/io/github/opendme/server/entity/Vehicle.java
@@ -1,15 +1,50 @@
 package io.github.opendme.server.entity;
 
-import jakarta.persistence.*;
-
-import java.util.Map;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity
-public record Vehicle(
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        @Column(nullable = false)
-        Long id,
-        String name,
-        Integer seats) {
+public class Vehicle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    Long id;
+    String name;
+    Integer seats;
+
+    public Vehicle() {
+    }
+
+    public Vehicle(Long id, String name, Integer seats) {
+        this.id = id;
+        this.name = name;
+        this.seats = seats;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getSeats() {
+        return seats;
+    }
+
+    public void setSeats(Integer seats) {
+        this.seats = seats;
+    }
 }

--- a/src/main/java/io/github/opendme/server/service/DepartmentService.java
+++ b/src/main/java/io/github/opendme/server/service/DepartmentService.java
@@ -7,7 +7,6 @@ import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.entity.MemberRepository;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.Optional;
@@ -32,8 +31,6 @@ public class DepartmentService {
     }
 
     private Member fetchAdmin(DepartmentDto department) {
-        if (ObjectUtils.isEmpty(department.getAdminId()))
-            throw new HttpClientErrorException(HttpStatusCode.valueOf(422), "Admin may not be empty.");
         Optional<Member> admin = memberRepository.findById(department.getAdminId());
         if (admin.isEmpty())
             throw new HttpClientErrorException(HttpStatusCode.valueOf(422), "Could not fetch admin.");

--- a/src/main/java/io/github/opendme/server/service/DepartmentService.java
+++ b/src/main/java/io/github/opendme/server/service/DepartmentService.java
@@ -22,7 +22,15 @@ public class DepartmentService {
     }
 
     public Department create(DepartmentDto department) {
-        return departmentRepository.save(mapToEntity(department));
+        Department d = departmentRepository.save(mapToEntity(department));
+        updateAdmin(d);
+        return d;
+    }
+
+    private void updateAdmin(Department d) {
+        Member admin = d.getAdmin();
+        admin.setDepartment(d);
+        memberRepository.save(admin);
     }
 
     Department mapToEntity(DepartmentDto dto) {

--- a/src/main/java/io/github/opendme/server/service/MemberService.java
+++ b/src/main/java/io/github/opendme/server/service/MemberService.java
@@ -1,0 +1,61 @@
+package io.github.opendme.server.service;
+
+import io.github.opendme.server.entity.Department;
+import io.github.opendme.server.entity.DepartmentRepository;
+import io.github.opendme.server.entity.Member;
+import io.github.opendme.server.entity.MemberDto;
+import io.github.opendme.server.entity.MemberRepository;
+import io.github.opendme.server.entity.Skill;
+import io.github.opendme.server.entity.SkillRepository;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+public class MemberService {
+    DepartmentRepository departmentRepository;
+    MemberRepository memberRepository;
+    SkillRepository skillRepository;
+
+    public MemberService(DepartmentRepository departmentRepository, MemberRepository memberRepository, SkillRepository skillRepository) {
+        this.departmentRepository = departmentRepository;
+        this.memberRepository = memberRepository;
+        this.skillRepository = skillRepository;
+    }
+
+    public Member create(MemberDto dto) {
+        validate(dto);
+        return memberRepository.save(mapToEntity(dto));
+    }
+
+    private void validate(MemberDto dto) {
+        if (dto.getDepartmentId() != null &&
+                !departmentRepository.existsById(dto.getDepartmentId()))
+            throw new HttpClientErrorException(HttpStatusCode.valueOf(422), "Department does not exist.");
+        if (skillsDontExist(dto))
+            throw new HttpClientErrorException(HttpStatusCode.valueOf(422), "Skills not valid.");
+    }
+
+    private boolean skillsDontExist(MemberDto dto) {
+        return !CollectionUtils.isEmpty(dto.getSkillIds()) &&
+                dto.getSkillIds().size() != skillRepository.countAllByIdIn(dto.getSkillIds());
+    }
+
+    private Member mapToEntity(MemberDto dto) {
+        Department department = null;
+        Set<Skill> skills = null;
+
+        if (Objects.nonNull(dto.getDepartmentId()))
+            department = departmentRepository.findById(dto.getDepartmentId()).get();
+
+        if (!CollectionUtils.isEmpty(dto.getSkillIds()))
+            skills = skillRepository.findAllByIdIn(dto.getSkillIds());
+
+        return new Member(null, department, dto.getName(), skills, dto.getEmail());
+    }
+
+}

--- a/src/test/java/io/github/opendme/ITBase.java
+++ b/src/test/java/io/github/opendme/ITBase.java
@@ -2,6 +2,7 @@ package io.github.opendme;
 
 import io.github.opendme.server.entity.DepartmentRepository;
 import io.github.opendme.server.entity.MemberRepository;
+import io.github.opendme.server.entity.SkillRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.web.servlet.MockMvc;
@@ -16,6 +17,8 @@ public class ITBase {
     protected DepartmentRepository departmentRepository;
     @Autowired
     protected MemberRepository memberRepository;
+    @Autowired
+    protected SkillRepository skillRepository;
 
     @Container
     @ServiceConnection

--- a/src/test/java/io/github/opendme/ITBase.java
+++ b/src/test/java/io/github/opendme/ITBase.java
@@ -4,10 +4,7 @@ import io.github.opendme.server.entity.DepartmentRepository;
 import io.github.opendme.server.entity.MemberRepository;
 import io.github.opendme.server.entity.SkillRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 
 @SpringBootIntegrationTest
 public class ITBase {
@@ -19,9 +16,5 @@ public class ITBase {
     protected MemberRepository memberRepository;
     @Autowired
     protected SkillRepository skillRepository;
-
-    @Container
-    @ServiceConnection
-    private static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
 }

--- a/src/test/java/io/github/opendme/SpringBootIntegrationTest.java
+++ b/src/test/java/io/github/opendme/SpringBootIntegrationTest.java
@@ -6,8 +6,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 

--- a/src/test/java/io/github/opendme/server/controller/DepartmentControllerIT.java
+++ b/src/test/java/io/github/opendme/server/controller/DepartmentControllerIT.java
@@ -5,9 +5,12 @@ import io.github.opendme.server.entity.DepartmentDto;
 import io.github.opendme.server.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectWriter;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.SerializationFeature;
@@ -17,6 +20,11 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 class DepartmentControllerIT extends ITBase {
+
+    @Container
+    @ServiceConnection
+    private static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
     @BeforeEach
     void setUp() {
         departmentRepository.deleteAll();

--- a/src/test/java/io/github/opendme/server/controller/MemberControllerIT.java
+++ b/src/test/java/io/github/opendme/server/controller/MemberControllerIT.java
@@ -1,11 +1,14 @@
 package io.github.opendme.server.controller;
 
 import io.github.opendme.ITBase;
-import io.github.opendme.server.entity.Department;
+import io.github.opendme.server.entity.DepartmentDto;
 import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.entity.MemberDto;
+import io.github.opendme.server.entity.Skill;
+import io.github.opendme.server.service.DepartmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -13,6 +16,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectWriter;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.SerializationFeature;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,14 +25,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 class MemberControllerIT extends ITBase {
     Long departmentId;
+    @Autowired
+    DepartmentService departmentService;
 
     @BeforeEach
     void setUp() {
+        memberRepository.removeAllDepartments();
         departmentRepository.deleteAll();
         memberRepository.deleteAll();
         skillRepository.deleteAll();
     }
-
 
     @Test
     @WithMockUser
@@ -51,15 +57,65 @@ class MemberControllerIT extends ITBase {
         assertThat(response.getContentAsString()).contains(departmentId.toString());
     }
 
+    @Test
+    @WithMockUser
+    void should_reject_invalid_department() throws Exception {
+        createDepartment();
+
+        MockHttpServletResponse response = sendCreateRequestWith(666L, null, "valid@mail.com");
+
+        assertThat(response.getStatus()).isEqualTo(422);
+    }
+
+    @Test
+    @WithMockUser
+    void should_create_member_with_all() throws Exception {
+        createDepartment();
+        List<Long> skills = createSkills();
+
+        MockHttpServletResponse response = sendCreateRequestWith(departmentId, skills, "valid@mail.com");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentAsString()).contains("Jon Doe");
+        assertThat(response.getContentAsString()).contains(departmentId.toString());
+        assertThat(response.getContentAsString()).contains("Atemschutzträger");
+    }
+
+    @Test
+    @WithMockUser
+    void should_reject_invalid_skill() throws Exception {
+        createSkills();
+
+        MockHttpServletResponse response = sendCreateRequestWith(null, List.of(9L), "valid@mail.com");
+
+        assertThat(response.getStatus()).isEqualTo(422);
+    }
+
+    @Test
+    @WithMockUser
+    void should_reject_invalid_email() throws Exception {
+        MockHttpServletResponse response = sendCreateRequestWith(null, null, "notValid.com");
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
     private void createDepartment() {
         Member admin = new Member(null, null, "master", null, "valid@mail.com");
         admin = memberRepository.save(admin);
-        Department d = new Department(null, "blub", admin);
-        departmentId = departmentRepository.save(d).getId();
+        departmentId = departmentService
+                .create(new DepartmentDto("blub", admin.getId()))
+                .getId();
     }
 
-    private MockHttpServletResponse sendCreateRequestWith(Long departmentId, List<Long> skillSet, String email) throws Exception {
-        MemberDto memberDto = new MemberDto(departmentId, "Jon Doe", skillSet, email);
+    private List<Long> createSkills() {
+        List<Long> skillIds = new ArrayList<>();
+        skillIds.add(skillRepository.save(new Skill(null, "Fahrer")).getId());
+        skillIds.add(skillRepository.save(new Skill(null, "Atemschutzträger")).getId());
+        return skillIds;
+    }
+
+    private MockHttpServletResponse sendCreateRequestWith(Long departmentId, List<Long> skills, String email) throws Exception {
+        MemberDto memberDto = new MemberDto(departmentId, "Jon Doe", skills, email);
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/src/test/java/io/github/opendme/server/controller/MemberControllerIT.java
+++ b/src/test/java/io/github/opendme/server/controller/MemberControllerIT.java
@@ -9,9 +9,12 @@ import io.github.opendme.server.service.DepartmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectWriter;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.SerializationFeature;
@@ -27,6 +30,10 @@ class MemberControllerIT extends ITBase {
     Long departmentId;
     @Autowired
     DepartmentService departmentService;
+
+    @Container
+    @ServiceConnection
+    private static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
Closes #15 

Created a controller to create members.

### Changes
- department creation now also updates the admin, setting the department reference
- fixed problems with json serialization of circular dependencies
  - serialization goes 1 level deep and just prints the id instead of serializing another level
- created custom update query to clear a department reference from all members
  - is needed before removing the department, to avoid foreign key problems
- introduce `spring-boot-starter-validation` to validate incoming dto´s