### PR TITLE
Create keycloak user on member creation

### DIFF
--- a/src/main/java/io/github/opendme/server/controller/MemberController.java
+++ b/src/main/java/io/github/opendme/server/controller/MemberController.java
@@ -23,8 +23,9 @@ public class MemberController {
     MemberService service;
     KeycloakService keycloakService;
 
-    public MemberController(MemberService service) {
+    public MemberController(MemberService service, KeycloakService keycloakService) {
         this.service = service;
+        this.keycloakService = keycloakService;
     }
 
     @PostMapping(value = "/member", produces = "application/json;charset=UTF-8")

--- a/src/main/java/io/github/opendme/server/controller/MemberController.java
+++ b/src/main/java/io/github/opendme/server/controller/MemberController.java
@@ -3,6 +3,7 @@ package io.github.opendme.server.controller;
 import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.entity.MemberDto;
 import io.github.opendme.server.entity.Status;
+import io.github.opendme.server.service.KeycloakService;
 import io.github.opendme.server.service.MemberService;
 import jakarta.validation.Valid;
 import org.apache.logging.log4j.LogManager;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private static final Logger log = LogManager.getLogger(MemberController.class);
     MemberService service;
+    KeycloakService keycloakService;
 
     public MemberController(MemberService service) {
         this.service = service;
@@ -31,6 +33,8 @@ public class MemberController {
     public Member create(@RequestBody @Valid MemberDto dto) {
         Member member = service.create(dto);
         log.atInfo().log("Member created");
+        keycloakService.createUser(member);
+        // TODO: Send creation mail with password c:
 
         return member;
     }

--- a/src/main/java/io/github/opendme/server/controller/MemberController.java
+++ b/src/main/java/io/github/opendme/server/controller/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
     public Member create(@RequestBody @Valid MemberDto dto) {
         Member member = service.create(dto);
         log.atInfo().log("Member created");
-        keycloakService.createUser(member);
+        var password = keycloakService.createUser(member);
         // TODO: Send creation mail with password c:
 
         return member;

--- a/src/main/java/io/github/opendme/server/service/KeycloakService.java
+++ b/src/main/java/io/github/opendme/server/service/KeycloakService.java
@@ -1,13 +1,19 @@
 package io.github.opendme.server.service;
 
 import io.github.opendme.server.config.KeycloakConfig;
+import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.service.keycloak.KeycloakInitializer;
 import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,9 +32,7 @@ public class KeycloakService {
 
     @PostConstruct
     public void init() {
-        if (config.isInitializeOnStartup()) {
-            keycloakInitializer.init(false);
-        }
+        keycloakInitializer.init(false);
     }
 
     public List<UserRepresentation> getInstanceAdmins() {
@@ -49,5 +53,32 @@ public class KeycloakService {
 
     private RealmResource realm() {
         return keycloak.realm(config.getRealm());
+    }
+
+    public void createUser(Member memberDto) {
+        UserRepresentation rep = createKeycloakUser(memberDto);
+
+        try (var res = realm().users().create(rep)) {
+            if (res.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
+                return;
+            }
+            // TODO: Check whether this is actually the best way.
+            throw new HttpClientErrorException(HttpStatusCode.valueOf(res.getStatus()), res.getStatusInfo().getReasonPhrase());
+        }
+    }
+
+    private static UserRepresentation createKeycloakUser(Member member) {
+        UserRepresentation rep = new UserRepresentation();
+        CredentialRepresentation cred = new CredentialRepresentation();
+        cred.setType(OAuth2Constants.PASSWORD);
+        cred.setValue("abc"); // TODO: Set actual random password
+        cred.setTemporary(true);
+        rep.setRequiredActions(List.of("UPDATE_PASSWORD"));
+        rep.setUsername(member.getName().toLowerCase().replace(" ", "."));
+        rep.setEmail(member.getEmail());
+        rep.setCredentials(List.of(cred));
+        rep.setEnabled(true);
+        rep.setGroups(List.of("user"));
+        return rep;
     }
 }

--- a/src/main/java/io/github/opendme/server/service/keycloak/KeycloakInitializer.java
+++ b/src/main/java/io/github/opendme/server/service/keycloak/KeycloakInitializer.java
@@ -15,7 +15,9 @@ import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -26,6 +28,7 @@ public class KeycloakInitializer {
     private final AppConfig appConfig;
     private final KeycloakConfig keycloakConfig;
     private final Keycloak keycloak;
+    private final Map<String, GroupRepresentation> groups = new HashMap<>();
 
     public KeycloakInitializer(AppConfig appConfig,
                                KeycloakConfig keycloakConfig,
@@ -81,6 +84,7 @@ public class KeycloakInitializer {
                 createdGroup = realmReq().getGroupByPath("/" + group.getName());
             }
             updateSubGroups(createdGroup, group.getSubGroups());
+            groups.put(group.getName(), createdGroup);
         }
     }
 
@@ -144,6 +148,10 @@ public class KeycloakInitializer {
         } catch (NotFoundException e) {
             log.error("Failed to reset Keycloak", e);
         }
+    }
+
+    public GroupRepresentation getDefaultGroup(String name) {
+        return groups.get(name);
     }
 
     private record KeycloakDefaults(List<GroupRepresentation> groups, List<RoleRepresentation> roles) {

--- a/src/test/java/io/github/opendme/ITBase.java
+++ b/src/test/java/io/github/opendme/ITBase.java
@@ -3,7 +3,9 @@ package io.github.opendme;
 import io.github.opendme.server.entity.DepartmentRepository;
 import io.github.opendme.server.entity.MemberRepository;
 import io.github.opendme.server.entity.SkillRepository;
+import io.github.opendme.server.service.KeycloakService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootIntegrationTest
@@ -17,4 +19,7 @@ public class ITBase {
     @Autowired
     protected SkillRepository skillRepository;
 
+    @MockBean
+    protected KeycloakService keycloakService;
+    //Not in test scope
 }

--- a/src/test/java/io/github/opendme/server/controller/DepartmentControllerIT.java
+++ b/src/test/java/io/github/opendme/server/controller/DepartmentControllerIT.java
@@ -29,7 +29,6 @@ class DepartmentControllerIT extends ITBase {
     void setUp() {
         departmentRepository.deleteAll();
         memberRepository.deleteAll();
-
     }
 
     @Test

--- a/src/test/java/io/github/opendme/server/controller/MemberControllerCreationIT.java
+++ b/src/test/java/io/github/opendme/server/controller/MemberControllerCreationIT.java
@@ -6,7 +6,6 @@ import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.entity.MemberDto;
 import io.github.opendme.server.entity.Skill;
 import io.github.opendme.server.service.DepartmentService;
-import io.github.opendme.server.service.KeycloakService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -38,8 +36,6 @@ class MemberControllerCreationIT extends ITBase {
     Long departmentId;
     @Autowired
     DepartmentService departmentService;
-    @MockBean
-    KeycloakService keycloakService;
     @Captor
     ArgumentCaptor<Member> memberCaptor;
 

--- a/src/test/java/io/github/opendme/server/controller/MemberControllerCreationIT.java
+++ b/src/test/java/io/github/opendme/server/controller/MemberControllerCreationIT.java
@@ -6,10 +6,15 @@ import io.github.opendme.server.entity.Member;
 import io.github.opendme.server.entity.MemberDto;
 import io.github.opendme.server.entity.Skill;
 import io.github.opendme.server.service.DepartmentService;
+import io.github.opendme.server.service.KeycloakService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -24,6 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -31,6 +38,13 @@ class MemberControllerCreationIT extends ITBase {
     Long departmentId;
     @Autowired
     DepartmentService departmentService;
+    @MockBean
+    KeycloakService keycloakService;
+    @Captor
+    ArgumentCaptor<Member> memberCaptor;
+
+    AutoCloseable openMocks;
+
 
     @Container
     @ServiceConnection
@@ -42,15 +56,24 @@ class MemberControllerCreationIT extends ITBase {
         departmentRepository.deleteAll();
         memberRepository.deleteAll();
         skillRepository.deleteAll();
+
+        openMocks = openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        openMocks.close();
     }
 
     @Test
     @WithMockUser
     void should_create_minimal_member() throws Exception {
-        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(null, "Jon Doe",  "valid@mail.com"));
+        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(null, "Jon Doe", "valid@mail.com"));
 
         assertThat(response.getStatus()).isEqualTo(201);
         assertThat(response.getContentAsString()).contains("Jon Doe");
+        verify(keycloakService).createUser(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getName()).isEqualTo("Jon Doe");
     }
 
     @Test
@@ -58,11 +81,13 @@ class MemberControllerCreationIT extends ITBase {
     void should_create_member_with_department() throws Exception {
         createDepartment();
 
-        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(departmentId, "Jon Doe",  "valid@mail.com"));
+        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(departmentId, "Jon Doe", "valid@mail.com"));
 
         assertThat(response.getStatus()).isEqualTo(201);
         assertThat(response.getContentAsString()).contains("Jon Doe");
         assertThat(response.getContentAsString()).contains(departmentId.toString());
+        verify(keycloakService).createUser(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getName()).isEqualTo("Jon Doe");
     }
 
     @Test
@@ -70,7 +95,7 @@ class MemberControllerCreationIT extends ITBase {
     void should_reject_invalid_department() throws Exception {
         createDepartment();
 
-        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(666L, "Jon Doe",  "valid@mail.com"));
+        MockHttpServletResponse response = sendCreateRequestWith(new MemberDto(666L, "Jon Doe", "valid@mail.com"));
 
         assertThat(response.getStatus()).isEqualTo(422);
     }
@@ -85,6 +110,8 @@ class MemberControllerCreationIT extends ITBase {
         assertThat(response.getStatus()).isEqualTo(201);
         assertThat(response.getContentAsString()).contains("Jon Doe");
         assertThat(response.getContentAsString()).contains(departmentId.toString());
+        verify(keycloakService).createUser(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getName()).isEqualTo("Jon Doe");
     }
 
     @Test


### PR DESCRIPTION
Issues with keyclock. We cant run the test without keycloak, but we also cant run the test with keycloak since the user creation would fail on a duplicated user